### PR TITLE
Zone interfaces

### DIFF
--- a/fortilib/fortigateapi.py
+++ b/fortilib/fortigateapi.py
@@ -214,6 +214,10 @@ class FortigateFirewallApi:
         """Get interfaces via Fortigate API"""
         return self.fortigate.get_firewall_interface()
 
+    def get_firewall_zone(self):
+        """Get zones via Fortigate API"""
+        return self.fortigate.get_firewall_zone()
+
     def get_firewall_route_static(self):
         """Get static routes via Fortigate API"""
         return self.fortigate.get_firewall_route_static()
@@ -615,6 +619,7 @@ class FortiGateApi:
     ENDPOINT_FIREWALL_PHASE2_INTERFACE = (
         "api/v2/cmdb/vpn.ipsec/phase2-interface/"
     )
+    ENDPOINT_FIREWALL_ZONE = "api/v2/cmdb/system/zone/"
     ENDPOINT_FIREWALL_IPPOOL = "api/v2/cmdb/firewall/ippool/"
     ENDPOINT_FIREWALL_VIP = "api/v2/cmdb/firewall/vip/"
     ENDPOINT_FIREWALL_VIP_GROUP = "api/v2/cmdb/firewall/vipgrp/"
@@ -890,6 +895,12 @@ class FortiGateApi:
     def get_firewall_interface(self, specific=False, filters=False):
         return self.query_api_get(
             FortiGateApi.ENDPOINT_FIREWALL_INTERFACE, specific, filters
+        )
+
+    # Firewall Interface Methods
+    def get_firewall_zone(self, specific=False, filters=False):
+        return self.query_api_get(
+            FortiGateApi.ENDPOINT_FIREWALL_ZONE, specific, filters
         )
 
     def get_ipsec_vpn(self, specific=False, filters=False):

--- a/fortilib/interface.py
+++ b/fortilib/interface.py
@@ -1,7 +1,17 @@
+from __future__ import annotations
+
+from typing import (
+    Dict,
+    List,
+    Union,
+)
 import ipaddress
 
+from fortilib import (
+    get_by,
+    get_fortigate_member_array,
+)
 from fortilib.base import FortigateNamedObject
-
 
 class FortigateInterface(FortigateNamedObject):
     """Fortigate object for interfaces.
@@ -14,7 +24,9 @@ class FortigateInterface(FortigateNamedObject):
         super().__init__()
 
         self.alias: str = ""
+        self.type: str = ""
         self.ip: ipaddress.IPv4Interface = None
+        self.zone: FortigateZone = None
 
     def __eq__(self, other):
         if isinstance(other, FortigateInterface):
@@ -30,6 +42,7 @@ class FortigateInterface(FortigateNamedObject):
         super().populate(object_data)
 
         self.alias = object_data.get("alias", self.alias)
+        self.type = object_data.get("type", self.type)
         if "ip" in object_data:
             self.ip = ipaddress.ip_interface(
                 "{}/{}".format(
@@ -37,6 +50,11 @@ class FortigateInterface(FortigateNamedObject):
                     object_data.get("ip", "0.0.0.0/0").split()[1],
                 )
             )
+
+    @staticmethod
+    def add_zone(zone: FortigateZone) -> FortigateInterface:
+        intf = FortigateInterface.from_dict({"name": zone.name, "type": "zone", "zone": zone})
+        return intf
 
     def render(self) -> dict:
         """Generate dict with all object arguments for fortigate api call.
@@ -47,6 +65,7 @@ class FortigateInterface(FortigateNamedObject):
                 {
                     "name": "Internet_interface",
                     "alias": "INTERNET",
+                    "type": "physical interface",
                     "ip": "2.235.23.16",
                     "comment": "Test comment",
                 }
@@ -54,9 +73,70 @@ class FortigateInterface(FortigateNamedObject):
         return {
             "name": self.name,
             "alias": self.alias,
+            "type ": self.type,
             "ip": f"{self.ip.ip} {self.ip.netmask}",
             "comment": self.comment,
         }
 
     def __repr__(self):
-        return f"{self.__class__.__name__} {self.name} IP: {self.ip} Alias: {self.alias}"
+        return f"{self.__class__.__name__} {self.name} IP: {self.ip} Alias: {self.alias} Type: {self.type}"
+
+
+
+
+class FortigateZone(FortigateNamedObject):
+    """Fortigate object for zones.
+
+    :ivar alias: Alternative name e.g. INTERNET
+    :ivar ip: Zone ip
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.intf: List[FortigateInterface] = []
+
+    def __eq__(self, other):
+        if isinstance(other, FortigateZone):
+            return (
+                self.name == other.name
+                and self.alias == other.alias
+                and self.intf == other.intf
+            )
+
+        return False
+
+    def populate(self, object_data: dict):
+        super().populate(object_data)
+
+    def find_interfaces(self, all_interfaces: List[FortigateInterface]) -> List[FortigateInterface]:
+        intf_arr: List[Dict] = self.object_data.get("interface")
+        for intf_dict in intf_arr:
+            name = intf_dict["interface-name"]
+            interface = get_by("name", name, all_interfaces)
+            if interface is None:
+                raise Exception(
+                    f"no interface found "
+                    f"with name {name}"
+                )
+            self.intf.append(interface)
+
+    def render(self) -> dict:
+        """Generate dict with all object arguments for fortigate api call.
+
+        :example:
+            .. code-block:: json
+
+                {
+                    "name": "Internet_zone",
+                    "intf": ["eth0",],
+                }
+        """
+        return {
+            "name": self.name,
+            "intf": self.intf,
+        }
+
+    def __repr__(self):
+        return f"{self.__class__.__name__} {self.name} Intf: {self.intf}"
+


### PR DESCRIPTION
issue: You can create zone that regroup several interfaces. Since zones are not retrieved then parsing of policies raise a exception for not finding the interfaces.

This patch gets all zones and add them as interfaces. So the policies can find them during the parsing.

The zones are retrieved with class FortigateZone in the attributes "zones" of FortigateFirewall.

Then a interface (class FortigateInterface) is created for each zone with type "zone" and the zone object in attribute.
